### PR TITLE
Make API consistent

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,8 +55,8 @@ like ``payload`` or ``extensions``.
 
 .. code-block:: python
 
-    r = c.payment_init(14, 1000000, 'http://twisto.dev/', 'Tesovaci nakup', customer_id='a@a.aa',
-                       return_method='GET', pay_operation='payment', merchant_data=[1, 2, 3])
+    r = c.payment_init(14, 1000000, 'http://twisto.dev/', 'Testovaci nakup', customer_id='a@a.aa',
+                       return_method=HttpMethod.GET, pay_operation=PayOperation.PAYMENT, merchant_data=[1, 2, 3])
     r.payload
     #[Out]# OrderedDict([('payId', 'b627c1e4e60fcBF'),
     #[Out]#              ('dttm', '20160615104254'),
@@ -98,7 +98,7 @@ appropriate enumerations are available.
         "pay_method": PayMethod.CARD,
         "currency": Currency.CZK,
         "close_payment": True,
-        "return_method": ReturnMethod.POST,
+        "return_method": HttpMethod.POST,
         "cart": [
             CartItem(name="Wireless sluchátka", quantity=2, amount=123400),
             CartItem(name="Doprava", quantity=1, amount=0, description="DPL"),
@@ -129,13 +129,13 @@ appropriate enumerations are available.
     r = c.payment_init(16, 123400, "http://twisto.dev/", "Testovací nákup", **data)
 
 
-Custom payments are initialized with ``c.payment_init(pay_operation='customPayment')``, you can optionally set 
+Custom payments are initialized with ``c.payment_init(pay_operation=PayOperation.CUSTOM_PAYMENT)``, you can optionally set 
 payment validity by ``custom_expiry='YYYYMMDDhhmmss'``.
 
 .. code-block:: python
 
-    r = c.payment_init(14, 1000000, 'http://twisto.dev/', 'Testovaci nakup', return_method='POST',
-                       pay_operation='customPayment', custom_expiry='20160630120000')
+    r = c.payment_init(14, 1000000, 'http://twisto.dev/', 'Testovaci nakup', return_method=HttpMethod.POST,
+                       pay_operation=PayOperation.CUSTOM_PAYMENT, custom_expiry='20160630120000')
     r.payload
     #[Out]# OrderedDict([('payId', 'b627c1e4e60fcBF'),
     #[Out]#              ('dttm', '20160615104254'),
@@ -148,40 +148,6 @@ payment validity by ``custom_expiry='YYYYMMDDhhmmss'``.
 Send (by whatever means) obtained ``customerCode`` to customer who can then perform payment anytime within its validity
 on URL ``https://platebnibrana.csob.cz/payment/{customerCode}`` (``c.get_payment_process_url`` is not applicable
 for custom payments).
-
-You can also use one-click payment methods. For this you need
-to call ``c.payment_init(pay_operation='oneclickPayment')``. After this transaction confirmed
-you can use obtained ``payId`` as template for one-click payment.
-
-.. code-block:: python
-
-    r = c.oneclick_init('1e058ff1d0d5aBF', 666, 10000)
-    r.payload
-    #[Out]# OrderedDict([('payId', 'ff7d3e7c6c4fdBF'),
-    #[Out]#              ('dttm', '20160615104532'),
-    #[Out]#              ('resultCode', 0),
-    #[Out]#              ('resultMessage', 'OK'),
-    #[Out]#              ('paymentStatus', 1),
-    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 45, 32))])
-
-    r = c.oneclick_start('ff7d3e7c6c4fdBF')
-    r.payload
-    #[Out]# OrderedDict([('payId', 'ff7d3e7c6c4fdBF'),
-    #[Out]#              ('dttm', '20160615104619'),
-    #[Out]#              ('resultCode', 0),
-    #[Out]#              ('resultMessage', 'OK'),
-    #[Out]#              ('paymentStatus', 2),
-    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 46, 19))])
-
-    r = c.payment_status('ff7d3e7c6c4fdBF')
-    r.payload
-    #[Out]# OrderedDict([('payId', 'ff7d3e7c6c4fdBF'),
-    #[Out]#              ('dttm', '20160615104643'),
-    #[Out]#              ('resultCode', 0),
-    #[Out]#              ('resultMessage', 'OK'),
-    #[Out]#              ('paymentStatus', 7),
-    #[Out]#              ('authCode', '168164'),
-    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 46, 43))])
 
 Of course you can use standard requests's methods on ``response`` object.
 

--- a/tests_pycsob/test_api.py
+++ b/tests_pycsob/test_api.py
@@ -10,7 +10,7 @@ import pytest
 from freezegun import freeze_time
 from pycsob import __version__, conf, utils
 from pycsob.client import (CartItem, CsobClient, Currency, CustomerAccount, Customer, CustomerLogin, CustomerLoginType,
-                           Language, OrderAddress, Order, OrderGiftcards, OrderType, PayOperation)
+                           HttpMethod, Language, OrderAddress, Order, OrderGiftcards, OrderType, PayOperation)
 from requests.exceptions import HTTPError
 from testfixtures import LogCapture
 from urllib3_mock import Responses
@@ -476,7 +476,7 @@ class CsobClientTests(TestCase):
     def test_http_status_raised(self):
         responses.add(responses.POST, '/echo/', status=500)
         with pytest.raises(HTTPError) as excinfo:
-            self.c.echo(method='POST')
+            self.c.echo(method=HttpMethod.POST)
         assert '500 Server Error' in str(excinfo.value)
         self.log_handler.check(
             ('pycsob', 'INFO', 'Pycsob request POST: https://gw.cz/echo/; Data: {"merchantId": "MERCHANT", '
@@ -495,7 +495,7 @@ class CsobClientTests(TestCase):
             ('paymentStatus', str(conf.PAYMENT_STATUS_WAITING)),
             ('authCode', 'F7A23E')
         ))
-        r = self.c.gateway_return(dict(resp_payload))
+        r = self.c._gateway_return(dict(resp_payload))
         assert type(r['paymentStatus']) == int
         assert type(r['resultCode']) == int
         self.log_handler.check()
@@ -506,7 +506,7 @@ class CsobClientTests(TestCase):
             ('paymentStatus', str(conf.PAYMENT_STATUS_WAITING)),
             ('merchantData', 'Rm9v')
         ))
-        r = self.c.gateway_return(dict(resp_payload))
+        r = self.c._gateway_return(dict(resp_payload))
         self.assertEqual(r, OrderedDict([
             ('resultCode', 110),
             ('paymentStatus', 7),


### PR DESCRIPTION
This is an attempt to apply changes and style introduced to `payment_init` also to other public methods of `CsobClient`. That is: adding type annotation, docstrings, links to documentation, etc. In `button_init` some already available enumerations were applied.

The section about oneclick payments in README file was removed as this payment method is currently not supported at all.