### PR TITLE
Make dttime timezone aware

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ like ``payload`` or ``extensions``.
     #[Out]#              ('resultMessage', 'OK'),
     #[Out]#              ('paymentStatus', 1),
     #[Out]#              ('merchantData', [1, 2, 3])]),
-    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 42, 54))])
+    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 42, 54, tzinfo=zoneinfo.ZoneInfo("Europe/Prague"))])
 
 After payment init get URL to redirect to for ``payId`` obtained from previous step.
 
@@ -85,7 +85,7 @@ You can check payment status.
     #[Out]#              ('resultMessage', 'OK'),
     #[Out]#              ('paymentStatus', 7),
     #[Out]#              ('authCode', '042760'),
-    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 45, 1))])
+    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 45, 1, tzinfo=zoneinfo.ZoneInfo("Europe/Prague"))])
 
 Structured data (i.e. ``cart``, ``customer`` and ``order``) are passed to ``payment_init`` as dataclasses, for some items
 appropriate enumerations are available.
@@ -143,7 +143,7 @@ payment validity by ``custom_expiry='YYYYMMDDhhmmss'``.
     #[Out]#              ('resultMessage', 'OK'),
     #[Out]#              ('paymentStatus', 1)]),
     #[Out]#              ('customerCode', 'E61EC8'),
-    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 42, 54))])
+    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 42, 54, tzinfo=zoneinfo.ZoneInfo("Europe/Prague"))])
 
 Send (by whatever means) obtained ``customerCode`` to customer who can then perform payment anytime within its validity
 on URL ``https://platebnibrana.csob.cz/payment/{customerCode}`` (``c.get_payment_process_url`` is not applicable
@@ -162,7 +162,7 @@ you can use obtained ``payId`` as template for one-click payment.
     #[Out]#              ('resultCode', 0),
     #[Out]#              ('resultMessage', 'OK'),
     #[Out]#              ('paymentStatus', 1),
-    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 45, 32))])
+    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 45, 32, tzinfo=zoneinfo.ZoneInfo("Europe/Prague"))])
 
     r = c.oneclick_start('ff7d3e7c6c4fdBF')
     r.payload
@@ -171,7 +171,7 @@ you can use obtained ``payId`` as template for one-click payment.
     #[Out]#              ('resultCode', 0),
     #[Out]#              ('resultMessage', 'OK'),
     #[Out]#              ('paymentStatus', 2),
-    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 46, 19))])
+    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 46, 19, tzinfo=zoneinfo.ZoneInfo("Europe/Prague"))])
 
     r = c.payment_status('ff7d3e7c6c4fdBF')
     r.payload
@@ -181,7 +181,7 @@ you can use obtained ``payId`` as template for one-click payment.
     #[Out]#              ('resultMessage', 'OK'),
     #[Out]#              ('paymentStatus', 7),
     #[Out]#              ('authCode', '168164'),
-    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 46, 43))])
+    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 46, 43, tzinfo=zoneinfo.ZoneInfo("Europe/Prague"))])
 
 Of course you can use standard requests's methods on ``response`` object.
 

--- a/pycsob/utils.py
+++ b/pycsob/utils.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import re
 import requests
+import zoneinfo
 from base64 import b64encode, b64decode
 from collections import OrderedDict
 from Crypto.Hash import SHA256
@@ -14,6 +15,8 @@ from . import conf
 from urllib.parse import urljoin, quote_plus
 
 LOGGER = logging.getLogger('pycsob')
+# See: https://github.com/csob/paymentgateway/wiki/Technical-FAQ#what-time-zone-should-be-used-for-dttm-parameter
+DEFAULT_TIMEZONE = "Europe/Prague"
 
 
 class CsobVerifyError(Exception):
@@ -102,9 +105,10 @@ def dttm(format_='%Y%m%d%H%M%S'):
     return datetime.datetime.now().strftime(format_)
 
 
-def dttm_decode(value):
-    """Decode dttm value '20190404091926' to the datetime object."""
-    return datetime.datetime.strptime(value, "%Y%m%d%H%M%S")
+def dttm_decode(value, timezone=DEFAULT_TIMEZONE):
+    """Decode dttm value '20190404091926' to the datetime object with timezone."""
+    dttm = datetime.datetime.strptime(value, "%Y%m%d%H%M%S")
+    return dttm.replace(tzinfo=zoneinfo.ZoneInfo(timezone))
 
 
 def validate_response(response, key):

--- a/tests_pycsob/test_api.py
+++ b/tests_pycsob/test_api.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import json
 import os
+import zoneinfo
 from collections import OrderedDict
 from datetime import datetime, timedelta, timezone
 from unittest import TestCase
@@ -148,7 +149,7 @@ class OrderTests(TestCase):
 class CsobClientTests(TestCase):
 
     dttm = "20190502161426"
-    dttime = datetime(2019, 5, 2, 16, 14, 26)
+    dttime = datetime(2019, 5, 2, 16, 14, 26, tzinfo=zoneinfo.ZoneInfo("Europe/Prague"))
 
     def setUp(self):
         self.c = CsobClient(merchant_id='MERCHANT',
@@ -669,8 +670,14 @@ class CsobClientTests(TestCase):
             ('pycsob', 'DEBUG', "Pycsob response headers: {'Content-Type': 'text/plain'}")
         )
 
-    def test_dttm_decode(self):
+    def test_dttm_decode_tzinfo_default(self):
         self.assertEqual(utils.dttm_decode("20190502161426"), self.dttime)
+
+    def test_dttm_decode_tzinfo_defined(self):
+        self.assertEqual(
+            utils.dttm_decode("20190502161426", timezone="UTC"),
+            datetime(2019, 5, 2, 16, 14, 26, tzinfo=timezone.utc),
+        )
 
     @responses.activate
     def test_description_strip(self):


### PR DESCRIPTION
Function `dttm_decode` is not timezone aware. It makes difficulties when the module is implemented to the Django. The default behaviour is changed to be timezone aware with an option to keep the original behaviour of the function.